### PR TITLE
fix: even bar chart spacing across non-contiguous stage IDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -388,7 +388,7 @@ if not df_improvements.empty:
     colors = ['#2ecc71' if x > 0 else '#e74c3c' for x in df_improvements['improvement']]
     
     fig2 = go.Figure(go.Bar(
-        x=df_improvements['stage_id'],
+        x=df_improvements['stage_id'].astype(str),
         y=df_improvements['improvement'],
         marker_color=colors,
         hovertemplate=(
@@ -397,11 +397,12 @@ if not df_improvements.empty:
             '<extra></extra>'
         )
     ))
-    
+
     fig2.update_layout(
         xaxis_title="Stage ID",
         yaxis_title="Cliques Reduced",
-        height=300
+        height=300,
+        xaxis=dict(type='category')
     )
     
     st.plotly_chart(fig2, width='stretch')


### PR DESCRIPTION
## Summary
- Cast `stage_id` to string and set `xaxis.type='category'` on the Improvement Per Stage bar chart
- Eliminates visible gaps that appear when a campaign's stage IDs are non-contiguous in the global sequence (now common with the parallel basin-probe campaigns 3-9)

## Test plan
- [x] Local image build (`benferenchak/ramsey-ui:multi-campaign-v2`) deployed to Portainer stack 7
- [ ] Confirm bar chart on http://localhost:36003 shows evenly-spaced bars for campaign 2 (which now skips stage IDs 5260-5266)

🤖 Generated with [Claude Code](https://claude.com/claude-code)