### PR TITLE
UI: fix edges dropped for vertex 0 (falsy-0 bug)

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,8 +94,14 @@ def get_best_results(redis_client, stage_id: int):
                 edges = []
                 if 'edgesToFlip' in data:
                     for edge in data['edgesToFlip']:
-                        u = edge.get('vertexOne') or edge.get('vertex_one')
-                        v = edge.get('vertexTwo') or edge.get('vertex_two')
+                        # NB: use None-coalescing, not `a or b` — vertex 0 is falsy
+                        # and `0 or ...` would wrongly drop edges involving vertex 0.
+                        u = edge.get('vertexOne')
+                        if u is None:
+                            u = edge.get('vertex_one')
+                        v = edge.get('vertexTwo')
+                        if v is None:
+                            v = edge.get('vertex_two')
                         if u is not None and v is not None:
                             edges.append((u, v))
 


### PR DESCRIPTION
Best-results rows for flips involving **vertex 0** rendered as "—" (45 entries live), and pair-flips silently dropped the 0-edge. Cause: `edge.get('vertexOne') or edge.get('vertex_one')` — 0 is falsy in Python, so it fell through to `None`. Switched to explicit None-coalescing. Verified live: 0 entries now render "—"; vertex-0 flips show `[(0, 281)]` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)