### PR TITLE
Stat cards: drive live from the socket (fix progress freeze) + drop throughput card

### DIFF
--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/LiveTick.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/LiveTick.java
@@ -1,0 +1,10 @@
+package com.setminusx.ramsey.ui.model;
+
+/**
+ * One per-second broadcast carrying both the throughput sample and the live stage stats,
+ * so the UI can drive the stat cards (stage, clique count, progress) straight off the socket
+ * and follow stage transitions without a stale REST poll.
+ */
+public record LiveTick(long ts, Integer stageId, double unitsPerSec,
+                       long processedCount, long workIndex, long totalPairs,
+                       double progressPct, Long cliqueCount) {}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/redis/RedisLiveStageService.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/redis/RedisLiveStageService.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Set;
 
 @Service
-public class RedisLiveStageService implements StageCounterReader {
+public class RedisLiveStageService {
 
     private final StringRedisTemplate redis;
     private final ObjectMapper objectMapper;
@@ -21,11 +21,6 @@ public class RedisLiveStageService implements StageCounterReader {
     public RedisLiveStageService(StringRedisTemplate redis, ObjectMapper objectMapper) {
         this.redis = redis;
         this.objectMapper = objectMapper;
-    }
-
-    @Override
-    public long readProcessedCount(int stageId) {
-        return getProcessedCount(stageId);
     }
 
     public long getProcessedCount(int stageId) {

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/redis/StageCounterReader.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/redis/StageCounterReader.java
@@ -1,5 +1,0 @@
-package com.setminusx.ramsey.ui.redis;
-
-public interface StageCounterReader {
-    long readProcessedCount(int stageId);
-}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStage.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStage.java
@@ -1,0 +1,4 @@
+package com.setminusx.ramsey.ui.sampler;
+
+/** The currently-active stage of the active campaign, with its graph's clique count. */
+public record ActiveStage(int stageId, Long cliqueCount) {}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolver.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolver.java
@@ -2,11 +2,9 @@ package com.setminusx.ramsey.ui.sampler;
 
 import com.setminusx.ramsey.ui.client.MwClient;
 import com.setminusx.ramsey.ui.model.CampaignDto;
-import com.setminusx.ramsey.ui.model.ProgressionPointDto;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
-import java.util.List;
 
 @Component
 public class ActiveStageResolver {
@@ -16,41 +14,40 @@ public class ActiveStageResolver {
     private final MwClient mw;
     private final Clock clock;
 
-    private Integer cachedStageId;
+    private ActiveStage cached;
     private long cachedAtMillis;
-    private boolean cached;
+    private boolean haveCached; // first call always computes (avoids a sentinel-overflow guard)
 
     public ActiveStageResolver(MwClient mw, Clock clock) {
         this.mw = mw;
         this.clock = clock;
     }
 
-    public synchronized Integer resolveActiveStageId() {
+    public synchronized ActiveStage resolveActiveStage() {
         long now = clock.millis();
-        if (cached && now - cachedAtMillis < CACHE_MILLIS) {
-            return cachedStageId;
+        if (haveCached && now - cachedAtMillis < CACHE_MILLIS) {
+            return cached;
         }
         try {
-            cachedStageId = computeActiveStageId();
+            cached = computeActiveStage();
         } catch (Exception e) {
-            cachedStageId = null; // mw unreachable -> no active stage; sampler emits 0
+            cached = null; // mw unreachable -> no active stage; sampler emits an empty tick
         }
         cachedAtMillis = now;
-        cached = true;
-        return cachedStageId;
+        haveCached = true;
+        return cached;
     }
 
-    private Integer computeActiveStageId() {
+    private ActiveStage computeActiveStage() {
         CampaignDto active = mw.getCampaigns().stream()
                 .filter(c -> "ACTIVE".equalsIgnoreCase(c.status()))
                 .findFirst()
                 .orElse(null);
         if (active == null) return null;
 
-        List<ProgressionPointDto> prog = mw.getProgression(active.campaignId());
-        return prog.stream()
+        return mw.getProgression(active.campaignId()).stream()
                 .filter(p -> "ACTIVE".equalsIgnoreCase(p.status()))
-                .map(ProgressionPointDto::stageId)
+                .map(p -> new ActiveStage(p.stageId(), p.cliqueCount()))
                 .findFirst()
                 .orElse(null);
     }

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ThroughputBroadcaster.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ThroughputBroadcaster.java
@@ -1,11 +1,11 @@
 package com.setminusx.ramsey.ui.sampler;
 
-import com.setminusx.ramsey.ui.model.ThroughputSample;
+import com.setminusx.ramsey.ui.model.LiveTick;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 public interface ThroughputBroadcaster {
-    void broadcast(ThroughputSample sample);
+    void broadcast(LiveTick tick);
 
     @Component
     class StompThroughputBroadcaster implements ThroughputBroadcaster {
@@ -14,8 +14,8 @@ public interface ThroughputBroadcaster {
         public StompThroughputBroadcaster(SimpMessagingTemplate messaging) {
             this.messaging = messaging;
         }
-        @Override public void broadcast(ThroughputSample sample) {
-            messaging.convertAndSend(TOPIC, sample);
+        @Override public void broadcast(LiveTick tick) {
+            messaging.convertAndSend(TOPIC, tick);
         }
     }
 }

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ThroughputSampler.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ThroughputSampler.java
@@ -1,7 +1,8 @@
 package com.setminusx.ramsey.ui.sampler;
 
+import com.setminusx.ramsey.ui.model.LiveTick;
 import com.setminusx.ramsey.ui.model.ThroughputSample;
-import com.setminusx.ramsey.ui.redis.StageCounterReader;
+import com.setminusx.ramsey.ui.redis.RedisLiveStageService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,20 +15,20 @@ public class ThroughputSampler {
 
     private static final Logger log = LoggerFactory.getLogger(ThroughputSampler.class);
 
-    private record Baseline(Integer stageId, long count, long ts) {}
+    private record Baseline(int stageId, long count, long ts) {}
 
     private final ActiveStageResolver resolver;
-    private final StageCounterReader counterReader;
+    private final RedisLiveStageService redis;
     private final ThroughputBuffer buffer;
     private final ThroughputBroadcaster broadcaster;
     private final Clock clock;
 
     private Baseline last;
 
-    public ThroughputSampler(ActiveStageResolver resolver, StageCounterReader counterReader,
+    public ThroughputSampler(ActiveStageResolver resolver, RedisLiveStageService redis,
                              ThroughputBuffer buffer, ThroughputBroadcaster broadcaster, Clock clock) {
         this.resolver = resolver;
-        this.counterReader = counterReader;
+        this.redis = redis;
         this.buffer = buffer;
         this.broadcaster = broadcaster;
         this.clock = clock;
@@ -40,40 +41,42 @@ public class ThroughputSampler {
         } catch (Exception e) {
             // Transient dependency failure (e.g., Redis blip). Skip this tick and keep the
             // baseline so the next successful read averages throughput across the gap.
-            log.debug("throughput sample skipped: {}", e.toString());
+            log.debug("live tick skipped: {}", e.toString());
         }
     }
 
     private void doSample() {
         long now = clock.millis();
-        Integer stageId = resolver.resolveActiveStageId();
+        ActiveStage active = resolver.resolveActiveStage();
 
-        if (stageId == null) {
+        if (active == null) {
             last = null;
-            emit(new ThroughputSample(now, null, 0.0));
+            emit(new LiveTick(now, null, 0.0, 0, 0, 0, 0.0, null));
             return;
         }
 
-        long count = counterReader.readProcessedCount(stageId);
+        int stageId = active.stageId();
+        long count = redis.getProcessedCount(stageId);
 
-        if (last == null || !stageId.equals(last.stageId())) {
-            last = new Baseline(stageId, count, now);
-            emit(new ThroughputSample(now, stageId, 0.0));
-            return;
-        }
-
-        double elapsedSec = (now - last.ts()) / 1000.0;
-        double unitsPerSec = 0.0;
-        if (elapsedSec > 0) {
+        double unitsPerSec;
+        if (last == null || last.stageId() != stageId) {
+            unitsPerSec = 0.0; // re-baseline on first sample / stage change (no cross-stage spike)
+        } else {
+            double elapsedSec = (now - last.ts()) / 1000.0;
             double delta = count - last.count();
-            unitsPerSec = delta > 0 ? delta / elapsedSec : 0.0;
+            unitsPerSec = (elapsedSec > 0 && delta > 0) ? delta / elapsedSec : 0.0;
         }
         last = new Baseline(stageId, count, now);
-        emit(new ThroughputSample(now, stageId, unitsPerSec));
+
+        long workIndex = redis.getWorkIndex(stageId);
+        long totalPairs = redis.getTotalPairs(stageId);
+        double progressPct = totalPairs > 0 ? Math.min(100.0, (workIndex * 100.0) / totalPairs) : 0.0;
+
+        emit(new LiveTick(now, stageId, unitsPerSec, count, workIndex, totalPairs, progressPct, active.cliqueCount()));
     }
 
-    private void emit(ThroughputSample sample) {
-        buffer.add(sample);
-        broadcaster.broadcast(sample);
+    private void emit(LiveTick tick) {
+        buffer.add(new ThroughputSample(tick.ts(), tick.stageId(), tick.unitsPerSec()));
+        broadcaster.broadcast(tick);
     }
 }

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolverTest.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolverTest.java
@@ -18,55 +18,54 @@ class ActiveStageResolverTest {
     private CampaignDto campaign(int id, String status) {
         return new CampaignDto(id, 8, 281, 600L, "S", status, "2026-06-14T10:00:00", "2026-06-16T12:00:00");
     }
-    private ProgressionPointDto stage(int id, String status) {
-        return new ProgressionPointDto(id, 1, 100L, status, "2026-06-16T12:00:00");
+    private ProgressionPointDto stage(int id, long clique, String status) {
+        return new ProgressionPointDto(id, 1, clique, status, "2026-06-16T12:00:00");
     }
 
     @Test
-    void resolves_active_stage_of_active_campaign() {
+    void resolves_active_stage_with_clique_count() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(1, "INACTIVE"), campaign(10, "ACTIVE")));
-        when(mw.getProgression(10)).thenReturn(List.of(stage(40, "COMPLETE"), stage(42, "ACTIVE")));
+        when(mw.getProgression(10)).thenReturn(List.of(stage(40, 999L, "COMPLETE"), stage(42, 775623L, "ACTIVE")));
 
-        ActiveStageResolver resolver = new ActiveStageResolver(mw, Clock.systemUTC());
-        assertThat(resolver.resolveActiveStageId()).isEqualTo(42);
+        ActiveStage active = new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStage();
+        assertThat(active).isNotNull();
+        assertThat(active.stageId()).isEqualTo(42);
+        assertThat(active.cliqueCount()).isEqualTo(775623L);
     }
 
     @Test
     void returns_null_when_no_active_campaign() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(1, "INACTIVE")));
-        ActiveStageResolver resolver = new ActiveStageResolver(mw, Clock.systemUTC());
-        assertThat(resolver.resolveActiveStageId()).isNull();
+        assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStage()).isNull();
     }
 
     @Test
     void returns_null_when_mw_unreachable() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenThrow(new RuntimeException("connection refused"));
-        ActiveStageResolver resolver = new ActiveStageResolver(mw, Clock.systemUTC());
-        assertThat(resolver.resolveActiveStageId()).isNull();
+        assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStage()).isNull();
     }
 
     @Test
     void caches_within_window_then_refreshes() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(10, "ACTIVE")));
-        when(mw.getProgression(10)).thenReturn(List.of(stage(42, "ACTIVE")));
+        when(mw.getProgression(10)).thenReturn(List.of(stage(42, 775623L, "ACTIVE")));
 
         MutableClock clock = new MutableClock(Instant.parse("2026-06-20T00:00:00Z"));
         ActiveStageResolver resolver = new ActiveStageResolver(mw, clock);
 
-        resolver.resolveActiveStageId();
-        resolver.resolveActiveStageId();
+        resolver.resolveActiveStage();
+        resolver.resolveActiveStage();
         verify(mw, times(1)).getCampaigns(); // cached, only one call
 
         clock.advanceSeconds(6);
-        resolver.resolveActiveStageId();
+        resolver.resolveActiveStage();
         verify(mw, times(2)).getCampaigns(); // cache expired, refreshed
     }
 
-    // Minimal adjustable clock for cache tests.
     static class MutableClock extends Clock {
         private Instant now;
         MutableClock(Instant start) { this.now = start; }

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputSamplerTest.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputSamplerTest.java
@@ -1,7 +1,8 @@
 package com.setminusx.ramsey.ui.sampler;
 
+import com.setminusx.ramsey.ui.model.LiveTick;
 import com.setminusx.ramsey.ui.model.ThroughputSample;
-import com.setminusx.ramsey.ui.redis.StageCounterReader;
+import com.setminusx.ramsey.ui.redis.RedisLiveStageService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -23,88 +24,74 @@ class ThroughputSamplerTest {
         @Override public Instant instant() { return now; }
     }
 
-    private ThroughputSample lastBroadcast(ThroughputBroadcaster b) {
-        ArgumentCaptor<ThroughputSample> cap = ArgumentCaptor.forClass(ThroughputSample.class);
-        verify(b, atLeastOnce()).broadcast(cap.capture());
+    private final ActiveStageResolver resolver = mock(ActiveStageResolver.class);
+    private final RedisLiveStageService redis = mock(RedisLiveStageService.class);
+    private final ThroughputBroadcaster broadcaster = mock(ThroughputBroadcaster.class);
+    private final ThroughputBuffer buffer = new ThroughputBuffer(100);
+    private final MutableClock clock = new MutableClock(Instant.parse("2026-06-20T00:00:00Z"));
+    private final ThroughputSampler sampler =
+            new ThroughputSampler(resolver, redis, buffer, broadcaster, clock);
+
+    private LiveTick lastBroadcast() {
+        ArgumentCaptor<LiveTick> cap = ArgumentCaptor.forClass(LiveTick.class);
+        verify(broadcaster, atLeastOnce()).broadcast(cap.capture());
         return cap.getValue();
     }
 
     @Test
-    void emits_zero_when_no_active_stage() {
-        ActiveStageResolver resolver = mock(ActiveStageResolver.class);
-        StageCounterReader reader = mock(StageCounterReader.class);
-        ThroughputBroadcaster broadcaster = mock(ThroughputBroadcaster.class);
-        ThroughputBuffer buffer = new ThroughputBuffer(100);
-        when(resolver.resolveActiveStageId()).thenReturn(null);
-
-        ThroughputSampler sampler = new ThroughputSampler(resolver, reader, buffer, broadcaster,
-                new MutableClock(Instant.parse("2026-06-20T00:00:00Z")));
+    void emits_empty_tick_when_no_active_stage() {
+        when(resolver.resolveActiveStage()).thenReturn(null);
         sampler.sample();
-
-        assertThat(lastBroadcast(broadcaster).unitsPerSec()).isZero();
-        assertThat(lastBroadcast(broadcaster).stageId()).isNull();
+        LiveTick t = lastBroadcast();
+        assertThat(t.stageId()).isNull();
+        assertThat(t.unitsPerSec()).isZero();
+        assertThat(t.progressPct()).isZero();
     }
 
     @Test
-    void first_sample_baselines_at_zero_then_computes_rate() {
-        ActiveStageResolver resolver = mock(ActiveStageResolver.class);
-        StageCounterReader reader = mock(StageCounterReader.class);
-        ThroughputBroadcaster broadcaster = mock(ThroughputBroadcaster.class);
-        ThroughputBuffer buffer = new ThroughputBuffer(100);
-        MutableClock clock = new MutableClock(Instant.parse("2026-06-20T00:00:00Z"));
-        when(resolver.resolveActiveStageId()).thenReturn(42);
+    void first_sample_baselines_then_computes_rate_and_progress() {
+        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 775623L));
+        when(redis.getWorkIndex(42)).thenReturn(300L);
+        when(redis.getTotalPairs(42)).thenReturn(600L);
 
-        ThroughputSampler sampler = new ThroughputSampler(resolver, reader, buffer, broadcaster, clock);
-
-        when(reader.readProcessedCount(42)).thenReturn(1000L);
-        sampler.sample(); // baseline, expect 0
+        when(redis.getProcessedCount(42)).thenReturn(1000L);
+        sampler.sample(); // baseline, expect 0/s
 
         clock.advanceMillis(1000);
-        when(reader.readProcessedCount(42)).thenReturn(1100L);
+        when(redis.getProcessedCount(42)).thenReturn(1100L);
         sampler.sample(); // +100 over 1s => 100/s
 
         assertThat(buffer.snapshot()).extracting(ThroughputSample::unitsPerSec)
                 .containsExactly(0.0, 100.0);
+        LiveTick t = lastBroadcast();
+        assertThat(t.stageId()).isEqualTo(42);
+        assertThat(t.unitsPerSec()).isEqualTo(100.0);
+        assertThat(t.progressPct()).isEqualTo(50.0);
+        assertThat(t.cliqueCount()).isEqualTo(775623L);
     }
 
     @Test
     void clamps_negative_rate_on_counter_reset() {
-        ActiveStageResolver resolver = mock(ActiveStageResolver.class);
-        StageCounterReader reader = mock(StageCounterReader.class);
-        ThroughputBroadcaster broadcaster = mock(ThroughputBroadcaster.class);
-        ThroughputBuffer buffer = new ThroughputBuffer(100);
-        MutableClock clock = new MutableClock(Instant.parse("2026-06-20T00:00:00Z"));
-        when(resolver.resolveActiveStageId()).thenReturn(42);
-
-        ThroughputSampler sampler = new ThroughputSampler(resolver, reader, buffer, broadcaster, clock);
-        when(reader.readProcessedCount(42)).thenReturn(5000L);
+        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 1L));
+        when(redis.getProcessedCount(42)).thenReturn(5000L);
         sampler.sample();
         clock.advanceMillis(1000);
-        when(reader.readProcessedCount(42)).thenReturn(10L); // reset
+        when(redis.getProcessedCount(42)).thenReturn(10L); // reset
         sampler.sample();
-
         assertThat(buffer.snapshot()).extracting(ThroughputSample::unitsPerSec)
                 .containsExactly(0.0, 0.0);
     }
 
     @Test
     void rebaselines_without_spike_on_stage_change() {
-        ActiveStageResolver resolver = mock(ActiveStageResolver.class);
-        StageCounterReader reader = mock(StageCounterReader.class);
-        ThroughputBroadcaster broadcaster = mock(ThroughputBroadcaster.class);
-        ThroughputBuffer buffer = new ThroughputBuffer(100);
-        MutableClock clock = new MutableClock(Instant.parse("2026-06-20T00:00:00Z"));
-
-        ThroughputSampler sampler = new ThroughputSampler(resolver, reader, buffer, broadcaster, clock);
-
-        when(resolver.resolveActiveStageId()).thenReturn(42);
-        when(reader.readProcessedCount(42)).thenReturn(1000L);
+        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 1L));
+        when(redis.getProcessedCount(42)).thenReturn(1000L);
         sampler.sample(); // baseline stage 42
 
         clock.advanceMillis(1000);
-        when(resolver.resolveActiveStageId()).thenReturn(43); // new stage
-        when(reader.readProcessedCount(43)).thenReturn(50L);
-        sampler.sample(); // re-baseline, expect 0 (no negative spike from 1000->50)
+        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(43, 1L)); // new stage
+        when(redis.getProcessedCount(43)).thenReturn(50L);
+        sampler.sample(); // re-baseline, expect 0 (no negative spike 1000->50)
 
         assertThat(buffer.snapshot()).extracting(ThroughputSample::unitsPerSec)
                 .containsExactly(0.0, 0.0);
@@ -112,18 +99,10 @@ class ThroughputSamplerTest {
     }
 
     @Test
-    void skips_tick_without_emitting_when_counter_read_fails() {
-        ActiveStageResolver resolver = mock(ActiveStageResolver.class);
-        StageCounterReader reader = mock(StageCounterReader.class);
-        ThroughputBroadcaster broadcaster = mock(ThroughputBroadcaster.class);
-        ThroughputBuffer buffer = new ThroughputBuffer(100);
-        when(resolver.resolveActiveStageId()).thenReturn(42);
-        when(reader.readProcessedCount(42)).thenThrow(new RuntimeException("redis down"));
-
-        ThroughputSampler sampler = new ThroughputSampler(resolver, reader, buffer, broadcaster,
-                new MutableClock(Instant.parse("2026-06-20T00:00:00Z")));
+    void skips_tick_without_emitting_when_redis_read_fails() {
+        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 1L));
+        when(redis.getProcessedCount(42)).thenThrow(new RuntimeException("redis down"));
         sampler.sample(); // must not throw
-
         assertThat(buffer.snapshot()).isEmpty();
         verifyNoInteractions(broadcaster);
     }

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputWebSocketIT.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputWebSocketIT.java
@@ -1,6 +1,6 @@
 package com.setminusx.ramsey.ui.sampler;
 
-import com.setminusx.ramsey.ui.model.ThroughputSample;
+import com.setminusx.ramsey.ui.model.LiveTick;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,28 +26,30 @@ class ThroughputWebSocketIT {
     @Autowired ThroughputBroadcaster broadcaster;
 
     @Test
-    void client_receives_broadcast_sample() throws Exception {
+    void client_receives_broadcast_tick() throws Exception {
         WebSocketStompClient stomp = new WebSocketStompClient(new StandardWebSocketClient());
         stomp.setMessageConverter(new JacksonJsonMessageConverter());
 
-        CompletableFuture<ThroughputSample> received = new CompletableFuture<>();
+        CompletableFuture<LiveTick> received = new CompletableFuture<>();
         StompSession session = stomp.connectAsync("ws://localhost:" + port + "/ws",
                 new StompSessionHandlerAdapter() {}).get(5, TimeUnit.SECONDS);
 
         session.subscribe("/topic/throughput", new StompFrameHandler() {
-            @Override public Type getPayloadType(StompHeaders headers) { return ThroughputSample.class; }
+            @Override public Type getPayloadType(StompHeaders headers) { return LiveTick.class; }
             @Override public void handleFrame(StompHeaders headers, Object payload) {
-                ThroughputSample s = (ThroughputSample) payload;
-                // Ignore any incidental sampler ticks; complete only on our explicit sample.
-                if (s.stageId() != null && s.stageId() == 42) received.complete(s);
+                LiveTick t = (LiveTick) payload;
+                // Ignore any incidental sampler ticks; complete only on our explicit one.
+                if (t.stageId() != null && t.stageId() == 42) received.complete(t);
             }
         });
 
         Thread.sleep(200); // allow subscription to register
-        broadcaster.broadcast(new ThroughputSample(123L, 42, 999.0));
+        broadcaster.broadcast(new LiveTick(123L, 42, 999.0, 1500, 300, 600, 50.0, 775623L));
 
-        ThroughputSample got = received.get(5, TimeUnit.SECONDS);
+        LiveTick got = received.get(5, TimeUnit.SECONDS);
         assertThat(got.stageId()).isEqualTo(42);
         assertThat(got.unitsPerSec()).isEqualTo(999.0);
+        assertThat(got.progressPct()).isEqualTo(50.0);
+        assertThat(got.cliqueCount()).isEqualTo(775623L);
     }
 }

--- a/ramsey-ui-web/src/App.tsx
+++ b/ramsey-ui-web/src/App.tsx
@@ -43,11 +43,6 @@ export default function App() {
     return () => { alive = false; clearInterval(h); };
   }, [activeStage?.stageId]);
 
-  // Smooth the headline stat over the last few samples so a single transient 0 at the
-  // live tail doesn't flicker the card to zero while work is clearly flowing.
-  const recentUps = samples.length
-    ? samples.slice(-5).reduce((a, s) => a + s.unitsPerSec, 0) / Math.min(5, samples.length)
-    : 0;
   const current = sortedProg[sortedProg.length - 1];
   const first = sortedProg[0];
 
@@ -58,7 +53,7 @@ export default function App() {
                lastUpdated={new Date().toLocaleTimeString()} connected={connected} />
       <main className="main">
         {current && first && (
-          <StatCards current={current} first={first} liveStage={liveStage} unitsPerSec={recentUps} />
+          <StatCards current={current} first={first} liveStage={liveStage} />
         )}
         <ThroughputChart samples={samples} interval={interval} />
         {progression.length > 0 && (

--- a/ramsey-ui-web/src/App.tsx
+++ b/ramsey-ui-web/src/App.tsx
@@ -8,15 +8,18 @@ import { ImprovementChart } from './components/ImprovementChart';
 import { BestResultsTable } from './components/BestResultsTable';
 import { RawDataTable } from './components/RawDataTable';
 import { useThroughputSocket } from './useThroughputSocket';
-import type { CampaignDto, ProgressionPointDto, LiveStageDto } from './types';
+import type { CampaignDto, ProgressionPointDto, BestResultDto } from './types';
 
 export default function App() {
   const [campaigns, setCampaigns] = useState<CampaignDto[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [progression, setProgression] = useState<ProgressionPointDto[]>([]);
-  const [liveStage, setLiveStage] = useState<LiveStageDto | null>(null);
+  const [bestResults, setBestResults] = useState<BestResultDto[]>([]);
   const [interval, setIntervalSec] = useState<Interval>(5);
-  const { samples, connected } = useThroughputSocket();
+  const { samples, latest, connected } = useThroughputSocket();
+
+  // The active stage reported by the live socket — drives transitions, not a stale fetch.
+  const liveStageId = latest?.stageId ?? null;
 
   useEffect(() => {
     api.getCampaigns().then((cs) => {
@@ -26,25 +29,33 @@ export default function App() {
     }).catch(() => undefined);
   }, []);
 
+  // (Re)fetch progression on campaign change AND whenever the live stage advances, so the
+  // charts/raw data pick up new stages without a manual reload.
   useEffect(() => {
     if (selectedId == null) return;
     api.getProgression(selectedId).then(setProgression).catch(() => undefined);
-  }, [selectedId]);
+  }, [selectedId, liveStageId]);
 
-  const sortedProg = [...progression].sort((a, b) => a.stageId - b.stageId);
-  const activeStage = progression.find((p) => p.status === 'ACTIVE') ?? null;
-
+  // Best-results for the live stage; polled and re-keyed when the stage changes.
   useEffect(() => {
-    if (!activeStage) { setLiveStage(null); return; }
+    if (liveStageId == null) { setBestResults([]); return; }
     let alive = true;
-    const tick = () => api.getLiveStage(activeStage.stageId).then((d) => { if (alive) setLiveStage(d); }).catch(() => undefined);
+    const tick = () => api.getLiveStage(liveStageId).then((d) => { if (alive) setBestResults(d.bestResults); }).catch(() => undefined);
     tick();
     const h = setInterval(tick, 5000);
     return () => { alive = false; clearInterval(h); };
-  }, [activeStage?.stageId]);
+  }, [liveStageId]);
 
-  const current = sortedProg[sortedProg.length - 1];
-  const first = sortedProg[0];
+  const sortedProg = [...progression].sort((a, b) => a.stageId - b.stageId);
+  const fallbackCurrent = sortedProg[sortedProg.length - 1];
+  const firstCliqueCount = sortedProg.length ? sortedProg[0].cliqueCount : null;
+
+  // Live scalars come from the socket; fall back to progression before the first tick arrives.
+  const stageId = latest?.stageId ?? fallbackCurrent?.stageId ?? null;
+  const cliqueCount = latest?.cliqueCount ?? fallbackCurrent?.cliqueCount ?? null;
+  const progressPct = latest?.progressPct ?? null;
+  const workIndex = latest?.workIndex ?? 0;
+  const totalPairs = latest?.totalPairs ?? 0;
 
   return (
     <div className="app">
@@ -52,9 +63,8 @@ export default function App() {
                interval={interval} onIntervalChange={setIntervalSec}
                lastUpdated={new Date().toLocaleTimeString()} connected={connected} />
       <main className="main">
-        {current && first && (
-          <StatCards current={current} first={first} liveStage={liveStage} />
-        )}
+        <StatCards stageId={stageId} cliqueCount={cliqueCount} firstCliqueCount={firstCliqueCount}
+                   progressPct={progressPct} workIndex={workIndex} totalPairs={totalPairs} />
         <ThroughputChart samples={samples} interval={interval} />
         {progression.length > 0 && (
           <>
@@ -62,7 +72,7 @@ export default function App() {
               <CliqueProgressionChart progression={progression} />
               <ImprovementChart progression={progression} />
             </div>
-            <BestResultsTable liveStage={liveStage} currentClique={current?.cliqueCount ?? 0} />
+            <BestResultsTable bestResults={bestResults} currentClique={cliqueCount ?? 0} />
             <RawDataTable progression={progression} />
           </>
         )}

--- a/ramsey-ui-web/src/components/BestResultsTable.tsx
+++ b/ramsey-ui-web/src/components/BestResultsTable.tsx
@@ -1,16 +1,15 @@
-import type { LiveStageDto } from '../types';
+import type { BestResultDto } from '../types';
 import { formatEdges } from '../format';
 import { Card } from './Card';
 
 const fmt = (n: number) => n.toLocaleString('en-US');
 
-export function BestResultsTable({ liveStage, currentClique }: {
-  liveStage: LiveStageDto | null; currentClique: number;
+export function BestResultsTable({ bestResults, currentClique }: {
+  bestResults: BestResultDto[]; currentClique: number;
 }) {
-  const rows = liveStage?.bestResults ?? [];
   return (
-    <Card title={`Best novel results · ${rows.length} retained`}>
-      {rows.length === 0 ? (
+    <Card title={`Best novel results · ${bestResults.length} retained`}>
+      {bestResults.length === 0 ? (
         <p className="muted">No results submitted yet for this stage.</p>
       ) : (
         <table>
@@ -18,7 +17,7 @@ export function BestResultsTable({ liveStage, currentClique }: {
             <tr><th>#</th><th className="num">Clique count</th><th className="num">Δ vs current</th><th>Edges to flip</th></tr>
           </thead>
           <tbody>
-            {rows.map((r, i) => (
+            {bestResults.map((r, i) => (
               <tr key={i}>
                 <td className="num">{i + 1}</td>
                 <td className="num">{fmt(r.cliqueCount)}</td>

--- a/ramsey-ui-web/src/components/StatCards.test.tsx
+++ b/ramsey-ui-web/src/components/StatCards.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { StatCards, sortCampaigns } from './StatCards';
-import type { CampaignDto, ProgressionPointDto, LiveStageDto } from '../types';
+import type { CampaignDto } from '../types';
 
 const camp = (id: number, status: string, updated: string): CampaignDto => ({
   campaignId: id, subgraphSize: 8, vertexCount: 281, totalPairs: 600,
@@ -20,12 +20,18 @@ describe('sortCampaigns', () => {
 });
 
 describe('StatCards', () => {
-  it('renders clique count and progress', () => {
-    const first: ProgressionPointDto = { stageId: 1, graphId: 1, cliqueCount: 800000, status: 'COMPLETE', createdDate: null };
-    const current: ProgressionPointDto = { stageId: 42, graphId: 2, cliqueCount: 775623, status: 'ACTIVE', createdDate: null };
-    const live: LiveStageDto = { stageId: 42, processedCount: 1500, workIndex: 300, totalPairs: 600, progressPct: 50, bestResults: [] };
-    render(<StatCards current={current} first={first} liveStage={live} />);
+  it('renders live stage, clique count and progress', () => {
+    render(<StatCards stageId={42} cliqueCount={775623} firstCliqueCount={800000}
+                      progressPct={50} workIndex={300} totalPairs={600} />);
+    expect(screen.getByText('#42')).toBeInTheDocument();
     expect(screen.getByText('775,623')).toBeInTheDocument();
     expect(screen.getByText('50.0%')).toBeInTheDocument();
+    expect(screen.getByText('24,377')).toBeInTheDocument(); // total improvement = 800000 - 775623
+  });
+
+  it('shows placeholders before any data', () => {
+    render(<StatCards stageId={null} cliqueCount={null} firstCliqueCount={null}
+                      progressPct={null} workIndex={0} totalPairs={0} />);
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
   });
 });

--- a/ramsey-ui-web/src/components/StatCards.test.tsx
+++ b/ramsey-ui-web/src/components/StatCards.test.tsx
@@ -20,13 +20,12 @@ describe('sortCampaigns', () => {
 });
 
 describe('StatCards', () => {
-  it('renders clique count and current throughput', () => {
+  it('renders clique count and progress', () => {
     const first: ProgressionPointDto = { stageId: 1, graphId: 1, cliqueCount: 800000, status: 'COMPLETE', createdDate: null };
     const current: ProgressionPointDto = { stageId: 42, graphId: 2, cliqueCount: 775623, status: 'ACTIVE', createdDate: null };
     const live: LiveStageDto = { stageId: 42, processedCount: 1500, workIndex: 300, totalPairs: 600, progressPct: 50, bestResults: [] };
-    render(<StatCards current={current} first={first} liveStage={live} unitsPerSec={123} />);
+    render(<StatCards current={current} first={first} liveStage={live} />);
     expect(screen.getByText('775,623')).toBeInTheDocument();
-    expect(screen.getByText(/123/)).toBeInTheDocument();
     expect(screen.getByText('50.0%')).toBeInTheDocument();
   });
 });

--- a/ramsey-ui-web/src/components/StatCards.tsx
+++ b/ramsey-ui-web/src/components/StatCards.tsx
@@ -1,4 +1,4 @@
-import type { CampaignDto, ProgressionPointDto, LiveStageDto } from '../types';
+import type { CampaignDto } from '../types';
 
 export function sortCampaigns(campaigns: CampaignDto[]): CampaignDto[] {
   const ts = (c: CampaignDto) => (c.updatedDate ? Date.parse(c.updatedDate) : 0);
@@ -25,22 +25,21 @@ function Stat({ label, value, unit, sub, subClass, primary }: {
   );
 }
 
-export function StatCards({ current, first, liveStage }: {
-  current: ProgressionPointDto; first: ProgressionPointDto; liveStage: LiveStageDto | null;
+export function StatCards({ stageId, cliqueCount, firstCliqueCount, progressPct, workIndex, totalPairs }: {
+  stageId: number | null; cliqueCount: number | null; firstCliqueCount: number | null;
+  progressPct: number | null; workIndex: number; totalPairs: number;
 }) {
   // positive improvement = clique count dropped from the start of the campaign
-  const improvement = first.cliqueCount - current.cliqueCount;
+  const improvement = (firstCliqueCount != null && cliqueCount != null) ? firstCliqueCount - cliqueCount : null;
   return (
     <div className="statcards">
-      <Stat label="Active Stage" value={`#${current.stageId}`} primary />
-      <Stat label="Clique Count" value={fmt(current.cliqueCount)}
-            sub={`${improvement >= 0 ? '−' : '+'}${fmt(Math.abs(improvement))} from start`}
-            subClass={improvement >= 0 ? 'stat__sub--up' : 'stat__sub--down'} />
-      <Stat label="Total Improvement" value={fmt(improvement)} />
-      <Stat label="Progress" value={liveStage ? `${liveStage.progressPct.toFixed(1)}%` : '—'}
-            sub={liveStage
-              ? `${fmt(Math.min(liveStage.workIndex, liveStage.totalPairs))} / ${fmt(liveStage.totalPairs)}`
-              : undefined} />
+      <Stat label="Active Stage" value={stageId != null ? `#${stageId}` : '—'} primary />
+      <Stat label="Clique Count" value={cliqueCount != null ? fmt(cliqueCount) : '—'}
+            sub={improvement != null ? `${improvement >= 0 ? '−' : '+'}${fmt(Math.abs(improvement))} from start` : undefined}
+            subClass={improvement != null ? (improvement >= 0 ? 'stat__sub--up' : 'stat__sub--down') : undefined} />
+      <Stat label="Total Improvement" value={improvement != null ? fmt(improvement) : '—'} />
+      <Stat label="Progress" value={progressPct != null ? `${progressPct.toFixed(1)}%` : '—'}
+            sub={totalPairs > 0 ? `${fmt(Math.min(workIndex, totalPairs))} / ${fmt(totalPairs)}` : undefined} />
     </div>
   );
 }

--- a/ramsey-ui-web/src/components/StatCards.tsx
+++ b/ramsey-ui-web/src/components/StatCards.tsx
@@ -25,9 +25,8 @@ function Stat({ label, value, unit, sub, subClass, primary }: {
   );
 }
 
-export function StatCards({ current, first, liveStage, unitsPerSec }: {
-  current: ProgressionPointDto; first: ProgressionPointDto;
-  liveStage: LiveStageDto | null; unitsPerSec: number;
+export function StatCards({ current, first, liveStage }: {
+  current: ProgressionPointDto; first: ProgressionPointDto; liveStage: LiveStageDto | null;
 }) {
   // positive improvement = clique count dropped from the start of the campaign
   const improvement = first.cliqueCount - current.cliqueCount;
@@ -42,7 +41,6 @@ export function StatCards({ current, first, liveStage, unitsPerSec }: {
             sub={liveStage
               ? `${fmt(Math.min(liveStage.workIndex, liveStage.totalPairs))} / ${fmt(liveStage.totalPairs)}`
               : undefined} />
-      <Stat label="Throughput" value={fmt(Math.round(unitsPerSec))} unit="u/s" />
     </div>
   );
 }

--- a/ramsey-ui-web/src/theme.css
+++ b/ramsey-ui-web/src/theme.css
@@ -150,7 +150,7 @@ body {
 /* ---------- stat readouts ---------- */
 .statcards {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 14px;
 }
 .stat {

--- a/ramsey-ui-web/src/types.ts
+++ b/ramsey-ui-web/src/types.ts
@@ -1,4 +1,12 @@
 export interface ThroughputSample { ts: number; stageId: number | null; unitsPerSec: number; }
+
+// Per-second socket payload: throughput + live stage stats, so the UI can drive the
+// stat cards straight off the socket and follow stage transitions.
+export interface LiveTick {
+  ts: number; stageId: number | null; unitsPerSec: number;
+  processedCount: number; workIndex: number; totalPairs: number;
+  progressPct: number; cliqueCount: number | null;
+}
 export interface BestResultDto { cliqueCount: number; edges: number[][]; fullGraph: boolean; }
 export interface LiveStageDto {
   stageId: number; processedCount: number; workIndex: number;

--- a/ramsey-ui-web/src/useThroughputSocket.ts
+++ b/ramsey-ui-web/src/useThroughputSocket.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
-import type { ThroughputSample } from './types';
+import type { ThroughputSample, LiveTick } from './types';
 import { api } from './api';
 import { mergeSample } from './throughput';
 
@@ -8,6 +8,7 @@ const MAX_POINTS = 7200;
 
 export function useThroughputSocket() {
   const [samples, setSamples] = useState<ThroughputSample[]>([]);
+  const [latest, setLatest] = useState<LiveTick | null>(null);
   const [connected, setConnected] = useState(false);
   const clientRef = useRef<Client | null>(null);
 
@@ -19,8 +20,10 @@ export function useThroughputSocket() {
       setConnected(true);
       api.getThroughputHistory(MAX_POINTS).then(setSamples).catch(() => undefined);
       client.subscribe('/topic/throughput', (msg) => {
-        const sample = JSON.parse(msg.body) as ThroughputSample;
-        setSamples((prev) => mergeSample(prev, sample, MAX_POINTS));
+        const tick = JSON.parse(msg.body) as LiveTick;
+        setLatest(tick);
+        setSamples((prev) =>
+          mergeSample(prev, { ts: tick.ts, stageId: tick.stageId, unitsPerSec: tick.unitsPerSec }, MAX_POINTS));
       });
     };
     client.onWebSocketClose = () => setConnected(false);
@@ -30,5 +33,5 @@ export function useThroughputSocket() {
     return () => { void client.deactivate(); };
   }, []);
 
-  return { samples, connected };
+  return { samples, latest, connected };
 }


### PR DESCRIPTION
Two related stat-card changes:

1. **Drop the redundant Throughput stat card** — it duplicated the big live wu/s panel's headline. Top row goes 5 → 4 cards.
2. **Drive the stat cards live off the WebSocket (fixes a freeze).** Active stage, clique count, and progress % were fetched once on page load, so when the queue manager advanced a stage they froze until reload — and could briefly disagree with the live throughput graph. The 1s broadcast is now a `LiveTick` carrying the live stage stats (stageId, clique count, processed/work-index/total, progress %), and the cards read straight off it. Progression + best-results refetch when the socket reports a new stage, so the charts/table follow transitions too. Removes the now-obsolete `StageCounterReader`.

Verified: 22 backend tests (incl. the STOMP WebSocket IT, now asserting the LiveTick fields) + 12 frontend tests; built and deployed to local Docker, confirmed live through nginx (stage/progress tracking the active stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)