### PR TITLE
Collapsible sidebar for full-width graphs in landscape

### DIFF
--- a/ramsey-ui-web/src/App.tsx
+++ b/ramsey-ui-web/src/App.tsx
@@ -16,6 +16,7 @@ export default function App() {
   const [progression, setProgression] = useState<ProgressionPointDto[]>([]);
   const [bestResults, setBestResults] = useState<BestResultDto[]>([]);
   const [interval, setIntervalSec] = useState<Interval>(5);
+  const [collapsed, setCollapsed] = useState(false);
   const { samples, latest, connected } = useThroughputSocket();
 
   // The active stage reported by the live socket — drives transitions, not a stale fetch.
@@ -58,10 +59,11 @@ export default function App() {
   const totalPairs = latest?.totalPairs ?? 0;
 
   return (
-    <div className="app">
+    <div className={`app${collapsed ? ' is-collapsed' : ''}`}>
       <Sidebar campaigns={campaigns} selectedId={selectedId} onSelect={setSelectedId}
                interval={interval} onIntervalChange={setIntervalSec}
-               lastUpdated={new Date().toLocaleTimeString()} connected={connected} />
+               lastUpdated={new Date().toLocaleTimeString()} connected={connected}
+               collapsed={collapsed} onToggleCollapse={() => setCollapsed((c) => !c)} />
       <main className="main">
         <StatCards stageId={stageId} cliqueCount={cliqueCount} firstCliqueCount={firstCliqueCount}
                    progressPct={progressPct} workIndex={workIndex} totalPairs={totalPairs} />

--- a/ramsey-ui-web/src/components/Sidebar.tsx
+++ b/ramsey-ui-web/src/components/Sidebar.tsx
@@ -3,13 +3,18 @@ import { sortCampaigns } from './StatCards';
 
 export type Interval = 1 | 5 | 30;
 
-export function Sidebar({ campaigns, selectedId, onSelect, interval, onIntervalChange, lastUpdated, connected }: {
+export function Sidebar({ campaigns, selectedId, onSelect, interval, onIntervalChange, lastUpdated, connected, collapsed, onToggleCollapse }: {
   campaigns: CampaignDto[]; selectedId: number | null; onSelect: (id: number) => void;
   interval: Interval; onIntervalChange: (i: Interval) => void; lastUpdated: string; connected: boolean;
+  collapsed: boolean; onToggleCollapse: () => void;
 }) {
   const sorted = sortCampaigns(campaigns);
   return (
     <aside className="sidebar">
+      <button className="sidebar__toggle" onClick={onToggleCollapse}
+              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'} aria-expanded={!collapsed}>
+        {collapsed ? '»' : '«'}
+      </button>
       <div className="sidebar__brand">
         <div className="sidebar__mark">RAM<span>SEY</span></div>
         <div className="sidebar__sub">search telemetry</div>

--- a/ramsey-ui-web/src/theme.css
+++ b/ramsey-ui-web/src/theme.css
@@ -67,6 +67,27 @@ body {
   color: var(--faint);
 }
 
+.sidebar__toggle {
+  position: absolute;
+  top: 16px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--panel-2);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.sidebar__toggle:hover { color: var(--text); border-color: var(--accent); }
+.sidebar__toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
 .field { display: flex; flex-direction: column; gap: 8px; }
 .field__label {
   font-family: var(--font-mono);
@@ -262,6 +283,16 @@ td.num, th.num { font-family: var(--font-mono); }
   .app { grid-template-columns: 1fr; }
   .sidebar { position: static; height: auto; flex-direction: row; flex-wrap: wrap; align-items: center; gap: 16px; }
   .rail-spacer { margin: 0; }
+  .sidebar__toggle { display: none; } /* portrait phone: sidebar stays as-is, no collapse */
+}
+
+/* Collapsible left sidebar in the two-column (desktop / landscape phone) layout, so the
+   graphs can take ~full width. Has no effect in the stacked <=760px portrait layout. */
+@media (min-width: 761px) {
+  .app.is-collapsed { grid-template-columns: 46px 1fr; }
+  .app.is-collapsed .sidebar { padding: 14px 0; align-items: center; }
+  .app.is-collapsed .sidebar > *:not(.sidebar__toggle) { display: none; }
+  .app.is-collapsed .sidebar__toggle { position: static; margin: 0 auto; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
On a phone in **landscape** the sidebar (brand + campaign + interval) sits on the left and eats horizontal space. This adds a **«/»** toggle that collapses it to a thin rail in the two-column layout (desktop / landscape phone), so the graphs take ~full width. Click **»** on the rail to bring it back.

**Portrait is unchanged** — in the stacked ≤760px layout the sidebar stays a top row and the toggle is hidden, so vertical phone use is exactly as before.

Verified at 844×390 (landscape, expanded + collapsed) and 390×844 (portrait); built and deployed to local Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)