### PR TITLE
Per-campaign live sampling: fix mixed dashboard under multiple ACTIVE campaigns

### DIFF
--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/LiveTick.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/LiveTick.java
@@ -1,10 +1,11 @@
 package com.setminusx.ramsey.ui.model;
 
 /**
- * One per-second broadcast carrying both the throughput sample and the live stage stats,
- * so the UI can drive the stat cards (stage, clique count, progress) straight off the socket
- * and follow stage transitions without a stale REST poll.
+ * One per-second broadcast per ACTIVE campaign, carrying both the throughput sample and the
+ * live stage stats, so the UI can drive the stat cards (stage, clique count, progress) straight
+ * off the socket and follow stage transitions without a stale REST poll. campaignId is null only
+ * on the idle heartbeat tick emitted when no campaign is active.
  */
-public record LiveTick(long ts, Integer stageId, double unitsPerSec,
+public record LiveTick(long ts, Integer campaignId, Integer stageId, double unitsPerSec,
                        long processedCount, long workIndex, long totalPairs,
                        double progressPct, Long cliqueCount) {}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/ThroughputSample.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/ThroughputSample.java
@@ -1,3 +1,3 @@
 package com.setminusx.ramsey.ui.model;
 
-public record ThroughputSample(long ts, Integer stageId, double unitsPerSec) {}
+public record ThroughputSample(long ts, Integer campaignId, Integer stageId, double unitsPerSec) {}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStage.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStage.java
@@ -1,4 +1,4 @@
 package com.setminusx.ramsey.ui.sampler;
 
-/** The currently-active stage of the active campaign, with its graph's clique count. */
-public record ActiveStage(int stageId, Long cliqueCount) {}
+/** The currently-active stage of one ACTIVE campaign, with its graph's clique count. */
+public record ActiveStage(int campaignId, int stageId, Long cliqueCount) {}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolver.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolver.java
@@ -1,10 +1,11 @@
 package com.setminusx.ramsey.ui.sampler;
 
 import com.setminusx.ramsey.ui.client.MwClient;
-import com.setminusx.ramsey.ui.model.CampaignDto;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
+import java.util.List;
+import java.util.Objects;
 
 @Component
 public class ActiveStageResolver {
@@ -14,7 +15,7 @@ public class ActiveStageResolver {
     private final MwClient mw;
     private final Clock clock;
 
-    private ActiveStage cached;
+    private List<ActiveStage> cached = List.of();
     private long cachedAtMillis;
     private boolean haveCached; // first call always computes (avoids a sentinel-overflow guard)
 
@@ -23,32 +24,35 @@ public class ActiveStageResolver {
         this.clock = clock;
     }
 
-    public synchronized ActiveStage resolveActiveStage() {
+    /**
+     * The active stage of EVERY campaign currently marked ACTIVE (the system may run several
+     * concurrently, e.g. the multi-seed campaign on the local fleet plus the long-running
+     * campaign the remote workers grind). Campaigns without an ACTIVE stage are omitted.
+     */
+    public synchronized List<ActiveStage> resolveActiveStages() {
         long now = clock.millis();
         if (haveCached && now - cachedAtMillis < CACHE_MILLIS) {
             return cached;
         }
         try {
-            cached = computeActiveStage();
+            cached = computeActiveStages();
         } catch (Exception e) {
-            cached = null; // mw unreachable -> no active stage; sampler emits an empty tick
+            cached = List.of(); // mw unreachable -> no active stages; sampler emits an empty tick
         }
         cachedAtMillis = now;
         haveCached = true;
         return cached;
     }
 
-    private ActiveStage computeActiveStage() {
-        CampaignDto active = mw.getCampaigns().stream()
+    private List<ActiveStage> computeActiveStages() {
+        return mw.getCampaigns().stream()
                 .filter(c -> "ACTIVE".equalsIgnoreCase(c.status()))
-                .findFirst()
-                .orElse(null);
-        if (active == null) return null;
-
-        return mw.getProgression(active.campaignId()).stream()
-                .filter(p -> "ACTIVE".equalsIgnoreCase(p.status()))
-                .map(p -> new ActiveStage(p.stageId(), p.cliqueCount()))
-                .findFirst()
-                .orElse(null);
+                .map(c -> mw.getProgression(c.campaignId()).stream()
+                        .filter(p -> "ACTIVE".equalsIgnoreCase(p.status()))
+                        .map(p -> new ActiveStage(c.campaignId(), p.stageId(), p.cliqueCount()))
+                        .findFirst()
+                        .orElse(null))
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ThroughputSampler.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ThroughputSampler.java
@@ -9,6 +9,11 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class ThroughputSampler {
@@ -23,7 +28,8 @@ public class ThroughputSampler {
     private final ThroughputBroadcaster broadcaster;
     private final Clock clock;
 
-    private Baseline last;
+    // per-campaign baselines: each ACTIVE campaign's rate is computed independently
+    private final Map<Integer, Baseline> last = new HashMap<>();
 
     public ThroughputSampler(ActiveStageResolver resolver, RedisLiveStageService redis,
                              ThroughputBuffer buffer, ThroughputBroadcaster broadcaster, Clock clock) {
@@ -47,36 +53,54 @@ public class ThroughputSampler {
 
     private void doSample() {
         long now = clock.millis();
-        ActiveStage active = resolver.resolveActiveStage();
+        List<ActiveStage> actives = resolver.resolveActiveStages();
 
-        if (active == null) {
-            last = null;
-            emit(new LiveTick(now, null, 0.0, 0, 0, 0, 0.0, null));
+        if (actives.isEmpty()) {
+            last.clear();
+            emit(new LiveTick(now, null, null, 0.0, 0, 0, 0, 0.0, null));
             return;
         }
 
+        // drop baselines of campaigns that are no longer active (banked/rotated away)
+        Set<Integer> activeIds = actives.stream().map(ActiveStage::campaignId).collect(Collectors.toSet());
+        last.keySet().retainAll(activeIds);
+
+        for (ActiveStage active : actives) {
+            try {
+                sampleCampaign(now, active);
+            } catch (Exception e) {
+                // one campaign's Redis blip must not starve the others' ticks
+                log.debug("live tick skipped for campaign {}: {}", active.campaignId(), e.toString());
+            }
+        }
+    }
+
+    private void sampleCampaign(long now, ActiveStage active) {
+        int campaignId = active.campaignId();
         int stageId = active.stageId();
         long count = redis.getProcessedCount(stageId);
 
+        Baseline base = last.get(campaignId);
         double unitsPerSec;
-        if (last == null || last.stageId() != stageId) {
+        if (base == null || base.stageId() != stageId) {
             unitsPerSec = 0.0; // re-baseline on first sample / stage change (no cross-stage spike)
         } else {
-            double elapsedSec = (now - last.ts()) / 1000.0;
-            double delta = count - last.count();
+            double elapsedSec = (now - base.ts()) / 1000.0;
+            double delta = count - base.count();
             unitsPerSec = (elapsedSec > 0 && delta > 0) ? delta / elapsedSec : 0.0;
         }
-        last = new Baseline(stageId, count, now);
+        last.put(campaignId, new Baseline(stageId, count, now));
 
         long workIndex = redis.getWorkIndex(stageId);
         long totalPairs = redis.getTotalPairs(stageId);
         double progressPct = totalPairs > 0 ? Math.min(100.0, (workIndex * 100.0) / totalPairs) : 0.0;
 
-        emit(new LiveTick(now, stageId, unitsPerSec, count, workIndex, totalPairs, progressPct, active.cliqueCount()));
+        emit(new LiveTick(now, campaignId, stageId, unitsPerSec, count, workIndex, totalPairs,
+                progressPct, active.cliqueCount()));
     }
 
     private void emit(LiveTick tick) {
-        buffer.add(new ThroughputSample(tick.ts(), tick.stageId(), tick.unitsPerSec()));
+        buffer.add(new ThroughputSample(tick.ts(), tick.campaignId(), tick.stageId(), tick.unitsPerSec()));
         broadcaster.broadcast(tick);
     }
 }

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/web/DashboardController.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/web/DashboardController.java
@@ -45,9 +45,14 @@ public class DashboardController {
     }
 
     @GetMapping("/throughput/history")
-    public List<ThroughputSample> history(@RequestParam(required = false) Integer window) {
+    public List<ThroughputSample> history(@RequestParam(required = false) Integer window,
+                                          @RequestParam(required = false) Integer campaignId) {
         int windowSeconds = window != null ? window : props.throughput().defaultWindowSeconds();
         long since = clock.millis() - windowSeconds * 1000L;
-        return throughputBuffer.snapshotSince(since);
+        List<ThroughputSample> samples = throughputBuffer.snapshotSince(since);
+        if (campaignId == null) {
+            return samples;
+        }
+        return samples.stream().filter(s -> campaignId.equals(s.campaignId())).toList();
     }
 }

--- a/ramsey-ui-rest/src/main/resources/application.yml
+++ b/ramsey-ui-rest/src/main/resources/application.yml
@@ -20,5 +20,5 @@ ramsey:
   sampler:
     interval-ms: 1000
   throughput:
-    buffer-capacity: 7200
+    buffer-capacity: 21600  # shared across ACTIVE campaigns (samples are tagged); 3 campaigns x 2h @ 1/s
     default-window-seconds: 7200

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolverTest.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolverTest.java
@@ -23,29 +23,56 @@ class ActiveStageResolverTest {
     }
 
     @Test
-    void resolves_active_stage_with_clique_count() {
+    void resolves_active_stage_with_clique_count_and_campaign_id() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(1, "INACTIVE"), campaign(10, "ACTIVE")));
         when(mw.getProgression(10)).thenReturn(List.of(stage(40, 999L, "COMPLETE"), stage(42, 775623L, "ACTIVE")));
 
-        ActiveStage active = new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStage();
-        assertThat(active).isNotNull();
-        assertThat(active.stageId()).isEqualTo(42);
-        assertThat(active.cliqueCount()).isEqualTo(775623L);
+        List<ActiveStage> actives = new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages();
+        assertThat(actives).containsExactly(new ActiveStage(10, 42, 775623L));
     }
 
     @Test
-    void returns_null_when_no_active_campaign() {
+    void resolves_one_active_stage_per_active_campaign() {
+        // The system runs multiple ACTIVE campaigns concurrently (e.g. the remote-fleet
+        // campaign 10 plus the local multi-seed campaign 12) — every one must be resolved,
+        // not just the first the middleware happens to list.
+        MwClient mw = mock(MwClient.class);
+        when(mw.getCampaigns()).thenReturn(List.of(
+                campaign(10, "ACTIVE"), campaign(11, "INACTIVE"), campaign(12, "ACTIVE")));
+        when(mw.getProgression(10)).thenReturn(List.of(stage(16023, 26031L, "ACTIVE")));
+        when(mw.getProgression(12)).thenReturn(List.of(stage(16022, 27668L, "ACTIVE")));
+
+        List<ActiveStage> actives = new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages();
+        assertThat(actives).containsExactly(
+                new ActiveStage(10, 16023, 26031L),
+                new ActiveStage(12, 16022, 27668L));
+        verify(mw, never()).getProgression(11);
+    }
+
+    @Test
+    void omits_active_campaign_that_has_no_active_stage() {
+        MwClient mw = mock(MwClient.class);
+        when(mw.getCampaigns()).thenReturn(List.of(campaign(10, "ACTIVE"), campaign(12, "ACTIVE")));
+        when(mw.getProgression(10)).thenReturn(List.of(stage(40, 999L, "COMPLETE")));
+        when(mw.getProgression(12)).thenReturn(List.of(stage(50, 27668L, "ACTIVE")));
+
+        assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages())
+                .containsExactly(new ActiveStage(12, 50, 27668L));
+    }
+
+    @Test
+    void returns_empty_when_no_active_campaign() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(1, "INACTIVE")));
-        assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStage()).isNull();
+        assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages()).isEmpty();
     }
 
     @Test
-    void returns_null_when_mw_unreachable() {
+    void returns_empty_when_mw_unreachable() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenThrow(new RuntimeException("connection refused"));
-        assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStage()).isNull();
+        assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages()).isEmpty();
     }
 
     @Test
@@ -57,12 +84,12 @@ class ActiveStageResolverTest {
         MutableClock clock = new MutableClock(Instant.parse("2026-06-20T00:00:00Z"));
         ActiveStageResolver resolver = new ActiveStageResolver(mw, clock);
 
-        resolver.resolveActiveStage();
-        resolver.resolveActiveStage();
+        resolver.resolveActiveStages();
+        resolver.resolveActiveStages();
         verify(mw, times(1)).getCampaigns(); // cached, only one call
 
         clock.advanceSeconds(6);
-        resolver.resolveActiveStage();
+        resolver.resolveActiveStages();
         verify(mw, times(2)).getCampaigns(); // cache expired, refreshed
     }
 

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputBufferTest.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputBufferTest.java
@@ -12,7 +12,7 @@ class ThroughputBufferTest {
     @Test
     void evicts_oldest_beyond_capacity() {
         ThroughputBuffer buffer = new ThroughputBuffer(3);
-        for (int i = 1; i <= 5; i++) buffer.add(new ThroughputSample(i, 1, i));
+        for (int i = 1; i <= 5; i++) buffer.add(new ThroughputSample(i, 1, 1, i));
         List<ThroughputSample> all = buffer.snapshot();
         assertThat(all).hasSize(3);
         assertThat(all.get(0).ts()).isEqualTo(3); // 1 and 2 evicted
@@ -22,9 +22,9 @@ class ThroughputBufferTest {
     @Test
     void snapshot_since_filters_by_timestamp() {
         ThroughputBuffer buffer = new ThroughputBuffer(100);
-        buffer.add(new ThroughputSample(1000, 1, 10));
-        buffer.add(new ThroughputSample(2000, 1, 20));
-        buffer.add(new ThroughputSample(3000, 1, 30));
+        buffer.add(new ThroughputSample(1000, 1, 1, 10));
+        buffer.add(new ThroughputSample(2000, 1, 1, 20));
+        buffer.add(new ThroughputSample(3000, 1, 1, 30));
         assertThat(buffer.snapshotSince(2000)).extracting(ThroughputSample::ts)
                 .containsExactly(2000L, 3000L);
     }

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputSamplerTest.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputSamplerTest.java
@@ -9,6 +9,7 @@ import org.mockito.ArgumentCaptor;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -38,11 +39,18 @@ class ThroughputSamplerTest {
         return cap.getValue();
     }
 
+    private List<LiveTick> allBroadcasts() {
+        ArgumentCaptor<LiveTick> cap = ArgumentCaptor.forClass(LiveTick.class);
+        verify(broadcaster, atLeastOnce()).broadcast(cap.capture());
+        return cap.getAllValues();
+    }
+
     @Test
     void emits_empty_tick_when_no_active_stage() {
-        when(resolver.resolveActiveStage()).thenReturn(null);
+        when(resolver.resolveActiveStages()).thenReturn(List.of());
         sampler.sample();
         LiveTick t = lastBroadcast();
+        assertThat(t.campaignId()).isNull();
         assertThat(t.stageId()).isNull();
         assertThat(t.unitsPerSec()).isZero();
         assertThat(t.progressPct()).isZero();
@@ -50,7 +58,7 @@ class ThroughputSamplerTest {
 
     @Test
     void first_sample_baselines_then_computes_rate_and_progress() {
-        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 775623L));
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(2, 42, 775623L)));
         when(redis.getWorkIndex(42)).thenReturn(300L);
         when(redis.getTotalPairs(42)).thenReturn(600L);
 
@@ -64,6 +72,7 @@ class ThroughputSamplerTest {
         assertThat(buffer.snapshot()).extracting(ThroughputSample::unitsPerSec)
                 .containsExactly(0.0, 100.0);
         LiveTick t = lastBroadcast();
+        assertThat(t.campaignId()).isEqualTo(2);
         assertThat(t.stageId()).isEqualTo(42);
         assertThat(t.unitsPerSec()).isEqualTo(100.0);
         assertThat(t.progressPct()).isEqualTo(50.0);
@@ -71,8 +80,68 @@ class ThroughputSamplerTest {
     }
 
     @Test
+    void samples_each_active_campaign_with_independent_baselines() {
+        // the multi-campaign case: local fleet on campaign 12, remote fleet on campaign 10 —
+        // each gets its own tick with its own rate, computed from its own baseline.
+        when(resolver.resolveActiveStages()).thenReturn(List.of(
+                new ActiveStage(10, 100, 26031L), new ActiveStage(12, 200, 27668L)));
+        when(redis.getProcessedCount(100)).thenReturn(1_000L);
+        when(redis.getProcessedCount(200)).thenReturn(50_000L);
+        sampler.sample(); // baseline both
+
+        clock.advanceMillis(1000);
+        when(redis.getProcessedCount(100)).thenReturn(1_250L);   // +250/s (remote)
+        when(redis.getProcessedCount(200)).thenReturn(650_000L); // +600K/s (local)
+        sampler.sample();
+
+        assertThat(buffer.snapshot()).extracting(ThroughputSample::campaignId, ThroughputSample::unitsPerSec)
+                .containsExactly(
+                        tuple(10, 0.0), tuple(12, 0.0),
+                        tuple(10, 250.0), tuple(12, 600_000.0));
+        List<LiveTick> ticks = allBroadcasts();
+        assertThat(ticks).hasSize(4);
+        assertThat(ticks.get(2).campaignId()).isEqualTo(10);
+        assertThat(ticks.get(2).unitsPerSec()).isEqualTo(250.0);
+        assertThat(ticks.get(3).campaignId()).isEqualTo(12);
+        assertThat(ticks.get(3).unitsPerSec()).isEqualTo(600_000.0);
+    }
+
+    @Test
+    void drops_baseline_when_campaign_goes_inactive_and_rebaselines_on_return() {
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(11, 42, 1L)));
+        when(redis.getProcessedCount(42)).thenReturn(1000L);
+        sampler.sample(); // baseline campaign 11
+
+        clock.advanceMillis(1000);
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(12, 50, 2L)));
+        when(redis.getProcessedCount(50)).thenReturn(10L);
+        sampler.sample(); // campaign 11 banked; 12 baselines at 0
+
+        clock.advanceMillis(1000);
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(11, 42, 1L)));
+        when(redis.getProcessedCount(42)).thenReturn(9_999_999L);
+        sampler.sample(); // 11 returns: stale baseline must be gone -> 0, not a huge spike
+
+        assertThat(buffer.snapshot()).extracting(ThroughputSample::unitsPerSec)
+                .containsExactly(0.0, 0.0, 0.0);
+    }
+
+    @Test
+    void one_campaigns_redis_failure_does_not_starve_the_other() {
+        when(resolver.resolveActiveStages()).thenReturn(List.of(
+                new ActiveStage(10, 100, 1L), new ActiveStage(12, 200, 2L)));
+        when(redis.getProcessedCount(100)).thenThrow(new RuntimeException("redis down"));
+        when(redis.getProcessedCount(200)).thenReturn(500L);
+
+        sampler.sample(); // must not throw; campaign 12 still emits
+
+        assertThat(buffer.snapshot()).extracting(ThroughputSample::campaignId)
+                .containsExactly(12);
+    }
+
+    @Test
     void clamps_negative_rate_on_counter_reset() {
-        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 1L));
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(2, 42, 1L)));
         when(redis.getProcessedCount(42)).thenReturn(5000L);
         sampler.sample();
         clock.advanceMillis(1000);
@@ -84,12 +153,12 @@ class ThroughputSamplerTest {
 
     @Test
     void rebaselines_without_spike_on_stage_change() {
-        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 1L));
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(2, 42, 1L)));
         when(redis.getProcessedCount(42)).thenReturn(1000L);
         sampler.sample(); // baseline stage 42
 
         clock.advanceMillis(1000);
-        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(43, 1L)); // new stage
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(2, 43, 1L))); // new stage
         when(redis.getProcessedCount(43)).thenReturn(50L);
         sampler.sample(); // re-baseline, expect 0 (no negative spike 1000->50)
 
@@ -100,10 +169,14 @@ class ThroughputSamplerTest {
 
     @Test
     void skips_tick_without_emitting_when_redis_read_fails() {
-        when(resolver.resolveActiveStage()).thenReturn(new ActiveStage(42, 1L));
+        when(resolver.resolveActiveStages()).thenReturn(List.of(new ActiveStage(2, 42, 1L)));
         when(redis.getProcessedCount(42)).thenThrow(new RuntimeException("redis down"));
         sampler.sample(); // must not throw
         assertThat(buffer.snapshot()).isEmpty();
         verifyNoInteractions(broadcaster);
+    }
+
+    private static org.assertj.core.groups.Tuple tuple(Object... values) {
+        return org.assertj.core.groups.Tuple.tuple(values);
     }
 }

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputWebSocketIT.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ThroughputWebSocketIT.java
@@ -44,7 +44,7 @@ class ThroughputWebSocketIT {
         });
 
         Thread.sleep(200); // allow subscription to register
-        broadcaster.broadcast(new LiveTick(123L, 42, 999.0, 1500, 300, 600, 50.0, 775623L));
+        broadcaster.broadcast(new LiveTick(123L, 2, 42, 999.0, 1500, 300, 600, 50.0, 775623L));
 
         LiveTick got = received.get(5, TimeUnit.SECONDS);
         assertThat(got.stageId()).isEqualTo(42);

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/web/DashboardControllerTest.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/web/DashboardControllerTest.java
@@ -48,13 +48,24 @@ class DashboardControllerTest {
 
     @Test
     void history_filters_by_window() {
-        buffer.add(new ThroughputSample(1000, 42, 0.0));
-        buffer.add(new ThroughputSample(2000, 42, 123.0));
+        buffer.add(new ThroughputSample(1000, 10, 42, 0.0));
+        buffer.add(new ThroughputSample(2000, 12, 43, 123.0));
         // clock=2000ms; window=2s => since=0 => both points
-        assertThat(controller.history(2)).hasSize(2);
+        assertThat(controller.history(2, null)).hasSize(2);
         // window=0 => since=2000 => only ts>=2000 => one point
-        assertThat(controller.history(0)).hasSize(1);
+        assertThat(controller.history(0, null)).hasSize(1);
         // null window => default (7200s) => since well before 1000 => all points
-        assertThat(controller.history(null)).hasSize(2);
+        assertThat(controller.history(null, null)).hasSize(2);
+    }
+
+    @Test
+    void history_filters_by_campaign() {
+        buffer.add(new ThroughputSample(1000, 10, 42, 5.0));
+        buffer.add(new ThroughputSample(1000, 12, 43, 7.0));
+        buffer.add(new ThroughputSample(2000, 12, 43, 9.0));
+        assertThat(controller.history(null, 12)).extracting(ThroughputSample::unitsPerSec)
+                .containsExactly(7.0, 9.0);
+        assertThat(controller.history(null, 10)).hasSize(1);
+        assertThat(controller.history(null, null)).hasSize(3);
     }
 }

--- a/ramsey-ui-web/src/App.tsx
+++ b/ramsey-ui-web/src/App.tsx
@@ -17,9 +17,15 @@ export default function App() {
   const [bestResults, setBestResults] = useState<BestResultDto[]>([]);
   const [interval, setIntervalSec] = useState<Interval>(5);
   const [collapsed, setCollapsed] = useState(false);
-  const { samples, latest, connected } = useThroughputSocket();
+  const { byCampaign, connected } = useThroughputSocket();
 
-  // The active stage reported by the live socket — drives transitions, not a stale fetch.
+  // Live view of the SELECTED campaign only — with several campaigns active, the socket
+  // carries per-campaign ticks and each campaign has its own live state.
+  const live = selectedId != null ? byCampaign[selectedId] : undefined;
+  const latest = live?.latest ?? null;
+  const samples = live?.samples ?? [];
+
+  // The selected campaign's active stage reported by the live socket — drives transitions.
   const liveStageId = latest?.stageId ?? null;
 
   useEffect(() => {

--- a/ramsey-ui-web/src/components/ThroughputChart.test.tsx
+++ b/ramsey-ui-web/src/components/ThroughputChart.test.tsx
@@ -15,7 +15,7 @@ vi.mock('recharts', async (importOriginal) => {
   };
 });
 
-const s = (ts: number, ups: number): ThroughputSample => ({ ts, stageId: 1, unitsPerSec: ups });
+const s = (ts: number, ups: number): ThroughputSample => ({ ts, campaignId: 1, stageId: 1, unitsPerSec: ups });
 
 describe('ThroughputChart', () => {
   it('shows the latest bucketed value as the headline', () => {

--- a/ramsey-ui-web/src/throughput.test.ts
+++ b/ramsey-ui-web/src/throughput.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { bucketSamples, mergeSample } from './throughput';
 import type { ThroughputSample } from './types';
 
-const s = (ts: number, ups: number): ThroughputSample => ({ ts, stageId: 1, unitsPerSec: ups });
+const s = (ts: number, ups: number): ThroughputSample => ({ ts, campaignId: 1, stageId: 1, unitsPerSec: ups });
 
 describe('bucketSamples', () => {
   it('passes 1s through unchanged', () => {

--- a/ramsey-ui-web/src/throughput.test.ts
+++ b/ramsey-ui-web/src/throughput.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { bucketSamples, mergeSample } from './throughput';
+import { bucketSamples, mergeHistory, mergeSample } from './throughput';
 import type { ThroughputSample } from './types';
 
 const s = (ts: number, ups: number): ThroughputSample => ({ ts, campaignId: 1, stageId: 1, unitsPerSec: ups });
@@ -23,5 +23,27 @@ describe('mergeSample', () => {
     let arr: ThroughputSample[] = [s(1000, 1), s(2000, 2)];
     arr = mergeSample(arr, s(3000, 3), 2);
     expect(arr.map((x) => x.ts)).toEqual([2000, 3000]);
+  });
+});
+
+describe('mergeHistory', () => {
+  const c = (ts: number, ups: number): ThroughputSample => ({ ts, campaignId: 12, stageId: 9, unitsPerSec: ups });
+
+  it('sorts history under live ticks that arrived first', () => {
+    // socket ticks (newer) landed before the REST history (older) resolved
+    const live = [c(5000, 50), c(6000, 60)];
+    const history = [c(1000, 10), c(2000, 20), c(3000, 30)];
+    const out = mergeHistory(live, history, 100);
+    expect(out.map((x) => x.ts)).toEqual([1000, 2000, 3000, 5000, 6000]);
+  });
+
+  it('dedupes samples with the same timestamp', () => {
+    const out = mergeHistory([c(1000, 10)], [c(1000, 10), c(2000, 20)], 100);
+    expect(out.map((x) => x.ts)).toEqual([1000, 2000]);
+  });
+
+  it('caps to the newest maxPoints', () => {
+    const out = mergeHistory([c(4000, 4)], [c(1000, 1), c(2000, 2), c(3000, 3)], 2);
+    expect(out.map((x) => x.ts)).toEqual([3000, 4000]);
   });
 });

--- a/ramsey-ui-web/src/throughput.ts
+++ b/ramsey-ui-web/src/throughput.ts
@@ -26,3 +26,18 @@ export function mergeSample(
   const next = [...prev, sample];
   return next.length > maxPoints ? next.slice(next.length - maxPoints) : next;
 }
+
+/**
+ * Merge a history fetch into samples that may already contain newer live ticks (the REST
+ * fetch resolves after the socket subscription starts). Result is ts-sorted, deduped by ts,
+ * and capped to the newest maxPoints — so the chart never sees out-of-order points.
+ */
+export function mergeHistory(
+  existing: ThroughputSample[], history: ThroughputSample[], maxPoints: number,
+): ThroughputSample[] {
+  const seen = new Set<number>();
+  const merged = [...existing, ...history]
+    .sort((a, b) => a.ts - b.ts)
+    .filter((s) => (seen.has(s.ts) ? false : (seen.add(s.ts), true)));
+  return merged.length > maxPoints ? merged.slice(merged.length - maxPoints) : merged;
+}

--- a/ramsey-ui-web/src/types.ts
+++ b/ramsey-ui-web/src/types.ts
@@ -1,9 +1,9 @@
-export interface ThroughputSample { ts: number; stageId: number | null; unitsPerSec: number; }
+export interface ThroughputSample { ts: number; campaignId: number | null; stageId: number | null; unitsPerSec: number; }
 
 // Per-second socket payload: throughput + live stage stats, so the UI can drive the
 // stat cards straight off the socket and follow stage transitions.
 export interface LiveTick {
-  ts: number; stageId: number | null; unitsPerSec: number;
+  ts: number; campaignId: number | null; stageId: number | null; unitsPerSec: number;
   processedCount: number; workIndex: number; totalPairs: number;
   progressPct: number; cliqueCount: number | null;
 }

--- a/ramsey-ui-web/src/useThroughputSocket.ts
+++ b/ramsey-ui-web/src/useThroughputSocket.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import type { ThroughputSample, LiveTick } from './types';
 import { api } from './api';
-import { mergeSample } from './throughput';
+import { mergeHistory, mergeSample } from './throughput';
 
 const MAX_POINTS = 7200;
 // A campaign whose ticks stop arriving (banked/rotated away) goes "not live" after this long.
@@ -31,11 +31,19 @@ export function useThroughputSocket() {
       setConnected(true);
       api.getThroughputHistory(MAX_POINTS).then((history) => {
         setByCampaign((prev) => {
-          const next: Record<number, CampaignLive> = { ...prev };
+          // Live ticks may already have arrived while the fetch was in flight — merge the
+          // (older) history UNDER them, sorted and deduped, so charts stay chronological.
+          const grouped = new Map<number, typeof history>();
           for (const s of history) {
             if (s.campaignId == null) continue;
-            const cur = next[s.campaignId] ?? { samples: [], latest: null };
-            next[s.campaignId] = { ...cur, samples: mergeSample(cur.samples, s, MAX_POINTS) };
+            const arr = grouped.get(s.campaignId) ?? [];
+            arr.push(s);
+            grouped.set(s.campaignId, arr);
+          }
+          const next: Record<number, CampaignLive> = { ...prev };
+          for (const [id, hist] of grouped) {
+            const cur = next[id] ?? { samples: [], latest: null };
+            next[id] = { ...cur, samples: mergeHistory(cur.samples, hist, MAX_POINTS) };
           }
           return next;
         });

--- a/ramsey-ui-web/src/useThroughputSocket.ts
+++ b/ramsey-ui-web/src/useThroughputSocket.ts
@@ -5,10 +5,21 @@ import { api } from './api';
 import { mergeSample } from './throughput';
 
 const MAX_POINTS = 7200;
+// A campaign whose ticks stop arriving (banked/rotated away) goes "not live" after this long.
+const STALE_MS = 10_000;
 
+export interface CampaignLive {
+  samples: ThroughputSample[];
+  latest: LiveTick | null;
+}
+
+/**
+ * One socket subscription carries ticks for EVERY active campaign (each tick is tagged with
+ * its campaignId); this hook buckets them per campaign so the UI can show the live view of
+ * whichever campaign is selected — not just whichever one the backend sampled first.
+ */
 export function useThroughputSocket() {
-  const [samples, setSamples] = useState<ThroughputSample[]>([]);
-  const [latest, setLatest] = useState<LiveTick | null>(null);
+  const [byCampaign, setByCampaign] = useState<Record<number, CampaignLive>>({});
   const [connected, setConnected] = useState(false);
   const clientRef = useRef<Client | null>(null);
 
@@ -18,12 +29,39 @@ export function useThroughputSocket() {
 
     client.onConnect = () => {
       setConnected(true);
-      api.getThroughputHistory(MAX_POINTS).then(setSamples).catch(() => undefined);
+      api.getThroughputHistory(MAX_POINTS).then((history) => {
+        setByCampaign((prev) => {
+          const next: Record<number, CampaignLive> = { ...prev };
+          for (const s of history) {
+            if (s.campaignId == null) continue;
+            const cur = next[s.campaignId] ?? { samples: [], latest: null };
+            next[s.campaignId] = { ...cur, samples: mergeSample(cur.samples, s, MAX_POINTS) };
+          }
+          return next;
+        });
+      }).catch(() => undefined);
+
       client.subscribe('/topic/throughput', (msg) => {
         const tick = JSON.parse(msg.body) as LiveTick;
-        setLatest(tick);
-        setSamples((prev) =>
-          mergeSample(prev, { ts: tick.ts, stageId: tick.stageId, unitsPerSec: tick.unitsPerSec }, MAX_POINTS));
+        setByCampaign((prev) => {
+          const next: Record<number, CampaignLive> = { ...prev };
+          if (tick.campaignId != null) {
+            const cur = next[tick.campaignId] ?? { samples: [], latest: null };
+            next[tick.campaignId] = {
+              samples: mergeSample(cur.samples,
+                { ts: tick.ts, campaignId: tick.campaignId, stageId: tick.stageId, unitsPerSec: tick.unitsPerSec },
+                MAX_POINTS),
+              latest: tick,
+            };
+          }
+          // expire "latest" for campaigns that stopped ticking (kept history stays charted)
+          for (const key of Object.keys(next)) {
+            const id = Number(key);
+            const l = next[id].latest;
+            if (l && tick.ts - l.ts > STALE_MS) next[id] = { ...next[id], latest: null };
+          }
+          return next;
+        });
       });
     };
     client.onWebSocketClose = () => setConnected(false);
@@ -33,5 +71,5 @@ export function useThroughputSocket() {
     return () => { void client.deactivate(); };
   }, []);
 
-  return { samples, latest, connected };
+  return { byCampaign, connected };
 }


### PR DESCRIPTION
## Problem

With more than one ACTIVE campaign (the remote-fleet campaign 10 plus the local multi-seed campaign 12), the dashboard showed a **mixed view of two different campaigns**:

- The stat boxes, throughput chart, and best-results table were driven by the live socket, whose `ActiveStageResolver` used `.findFirst()` over ACTIVE campaigns → the first campaign the middleware returned (campaign 10, the remote fleet: slow stage cadence, spiky batch-quantized u/s).
- The progression/history charts and the improvement baseline used the frontend's `sortCampaigns()[0]` → the most-recently-updated ACTIVE campaign (campaign 12, hours old → "less history").

Symptoms: barely-moving stat boxes, an improvement figure mixing one campaign's start with another's live count, and a dropdown that changed the charts but never the boxes.

## Fix

**Backend** — resolve and sample *every* ACTIVE campaign:
- `ActiveStageResolver.resolveActiveStages()` returns one `ActiveStage` per ACTIVE campaign (5s cache unchanged).
- `ThroughputSampler` keeps **per-campaign baselines**, emits one campaign-tagged `LiveTick` per campaign per second, prunes baselines when a campaign is banked (no stale-spike on return), and isolates per-campaign Redis failures. The idle heartbeat tick (all campaigns inactive) is retained.
- `LiveTick` / `ThroughputSample` carry `campaignId`; `/api/dashboard/throughput/history` accepts an optional `campaignId` filter; buffer capacity 7200 → 21600 (shared across campaigns).

**Frontend** — follow the *selected* campaign:
- `useThroughputSocket` buckets ticks per campaign (`byCampaign`), seeds each bucket from history on connect, and expires a campaign's `latest` 10s after its ticks stop (rotation-away → boxes fall back to progression data).
- `App` derives the stat cards, throughput chart, live stage id, and best-results polling from `byCampaign[selectedId]` — so the sidebar dropdown now switches the *entire* view coherently.

## Testing

- Backend: 27 tests green — new coverage for per-campaign resolution, independent baselines, baseline pruning across a rotation, per-campaign failure isolation, and the history filter.
- Frontend: `npm run build` + 12 vitest green.
- **Verified against the live two-campaign stack** (image deployed locally): per-second ticks for both campaigns — campaign 12 showing the local fleet's true ~2.2M u/s, campaign 10 ticking independently on its own stage — and the history endpoint returning correctly tagged samples for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5swg6w4mqUe6X1dY5M93T