### PR TITLE
Resolve the active stage from the stage table, not the whole progression

### DIFF
--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/client/MwClient.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/client/MwClient.java
@@ -2,6 +2,8 @@ package com.setminusx.ramsey.ui.client;
 
 import com.setminusx.ramsey.ui.config.RamseyProperties;
 import com.setminusx.ramsey.ui.model.CampaignDto;
+import com.setminusx.ramsey.ui.model.GraphDto;
+import com.setminusx.ramsey.ui.model.StageDto;
 import com.setminusx.ramsey.ui.model.FleetDto;
 import com.setminusx.ramsey.ui.model.ProgressionPointDto;
 import org.springframework.core.ParameterizedTypeReference;
@@ -33,6 +35,32 @@ public class MwClient {
                 .retrieve()
                 .body(new ParameterizedTypeReference<>() {});
         return body != null ? body : List.of();
+    }
+
+    /**
+     * A campaign's ACTIVE stage, straight from the stage table.
+     *
+     * The obvious-looking alternative — scan the progression for the point marked ACTIVE — costs
+     * the WHOLE series (21 MB and 143,000 points, growing with every stage advance) to extract one
+     * stage id. This is a couple of hundred bytes and is indexed on (campaign_id, status).
+     */
+    public List<StageDto> getActiveStages(int campaignId) {
+        List<StageDto> body = restClient.get()
+                .uri(uri -> uri.path("/api/ramsey/stages")
+                        .queryParam("campaignId", campaignId)
+                        .queryParam("status", "ACTIVE")
+                        .build())
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+        return body != null ? body : List.of();
+    }
+
+    /** A graph's metadata by id. The response carries its bitstring; {@link GraphDto} drops it. */
+    public GraphDto getGraph(int graphId) {
+        return restClient.get()
+                .uri("/api/ramsey/graphs/{id}", graphId)
+                .retrieve()
+                .body(GraphDto.class);
     }
 
     public List<FleetDto> getFleets() {

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/GraphDto.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/GraphDto.java
@@ -1,0 +1,7 @@
+package com.setminusx.ramsey.ui.model;
+
+/**
+ * A graph's metadata. {@code edgeData} is deliberately not mapped — it is ~40 KB of bitstring the
+ * dashboard never reads, and leaving it off the record keeps it out of the deserialized object.
+ */
+public record GraphDto(Integer graphId, Integer cliqueCount, Integer vertexCount) {}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/StageDto.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/model/StageDto.java
@@ -1,0 +1,4 @@
+package com.setminusx.ramsey.ui.model;
+
+/** A stage as the middleware reports it. Only the fields the dashboard needs are mapped. */
+public record StageDto(Integer stageId, Integer campaignId, Integer baseGraphId, String status) {}

--- a/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolver.java
+++ b/ramsey-ui-rest/src/main/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolver.java
@@ -1,6 +1,7 @@
 package com.setminusx.ramsey.ui.sampler;
 
 import com.setminusx.ramsey.ui.client.MwClient;
+import com.setminusx.ramsey.ui.model.GraphDto;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
@@ -44,15 +45,41 @@ public class ActiveStageResolver {
         return cached;
     }
 
+    /**
+     * Ask the stage table directly rather than scanning a campaign's progression for the point
+     * marked ACTIVE.
+     *
+     * The progression is the whole history — 21 MB and 143,000 points at the time of writing, and
+     * it grows with every stage advance — so scanning it for one stage id cost a multi-megabyte
+     * query, serialisation and parse every refresh, for a few hundred bytes of answer. Worse, that
+     * cost grows without bound while the answer stays the same size.
+     */
     private List<ActiveStage> computeActiveStages() {
         return mw.getCampaigns().stream()
                 .filter(c -> "ACTIVE".equalsIgnoreCase(c.status()))
-                .map(c -> mw.getProgression(c.campaignId()).stream()
-                        .filter(p -> "ACTIVE".equalsIgnoreCase(p.status()))
-                        .map(p -> new ActiveStage(c.campaignId(), p.stageId(), p.cliqueCount()))
+                .map(c -> mw.getActiveStages(c.campaignId()).stream()
                         .findFirst()
+                        .map(stage -> new ActiveStage(
+                                c.campaignId(),
+                                stage.stageId(),
+                                cliqueCountOf(stage.baseGraphId())))
                         .orElse(null))
                 .filter(Objects::nonNull)
                 .toList();
+    }
+
+    /** The stage's base-graph clique count; null rather than failing the whole refresh. */
+    private Long cliqueCountOf(Integer baseGraphId) {
+        if (baseGraphId == null) {
+            return null;
+        }
+        try {
+            GraphDto graph = mw.getGraph(baseGraphId);
+            return graph == null || graph.cliqueCount() == null
+                    ? null
+                    : graph.cliqueCount().longValue();
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolverTest.java
+++ b/ramsey-ui-rest/src/test/java/com/setminusx/ramsey/ui/sampler/ActiveStageResolverTest.java
@@ -2,7 +2,8 @@ package com.setminusx.ramsey.ui.sampler;
 
 import com.setminusx.ramsey.ui.client.MwClient;
 import com.setminusx.ramsey.ui.model.CampaignDto;
-import com.setminusx.ramsey.ui.model.ProgressionPointDto;
+import com.setminusx.ramsey.ui.model.StageDto;
+import com.setminusx.ramsey.ui.model.GraphDto;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
@@ -11,6 +12,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 class ActiveStageResolverTest {
@@ -18,15 +20,13 @@ class ActiveStageResolverTest {
     private CampaignDto campaign(int id, String status) {
         return new CampaignDto(id, 8, 281, 600L, "S", status, "2026-06-14T10:00:00", "2026-06-16T12:00:00");
     }
-    private ProgressionPointDto stage(int id, long clique, String status) {
-        return new ProgressionPointDto(id, 1, clique, status, "2026-06-16T12:00:00", null, null);
-    }
 
     @Test
     void resolves_active_stage_with_clique_count_and_campaign_id() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(1, "INACTIVE"), campaign(10, "ACTIVE")));
-        when(mw.getProgression(10)).thenReturn(List.of(stage(40, 999L, "COMPLETE"), stage(42, 775623L, "ACTIVE")));
+        when(mw.getActiveStages(10)).thenReturn(List.of(new StageDto(42, 10, 4200, "ACTIVE")));
+        when(mw.getGraph(4200)).thenReturn(new GraphDto(4200, 775623, 282));
 
         List<ActiveStage> actives = new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages();
         assertThat(actives).containsExactly(new ActiveStage(10, 42, 775623L));
@@ -40,22 +40,25 @@ class ActiveStageResolverTest {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(
                 campaign(10, "ACTIVE"), campaign(11, "INACTIVE"), campaign(12, "ACTIVE")));
-        when(mw.getProgression(10)).thenReturn(List.of(stage(16023, 26031L, "ACTIVE")));
-        when(mw.getProgression(12)).thenReturn(List.of(stage(16022, 27668L, "ACTIVE")));
+        when(mw.getActiveStages(10)).thenReturn(List.of(new StageDto(16023, 10, 5001, "ACTIVE")));
+        when(mw.getGraph(5001)).thenReturn(new GraphDto(5001, 26031, 282));
+        when(mw.getActiveStages(12)).thenReturn(List.of(new StageDto(16022, 12, 5002, "ACTIVE")));
+        when(mw.getGraph(5002)).thenReturn(new GraphDto(5002, 27668, 282));
 
         List<ActiveStage> actives = new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages();
         assertThat(actives).containsExactly(
                 new ActiveStage(10, 16023, 26031L),
                 new ActiveStage(12, 16022, 27668L));
-        verify(mw, never()).getProgression(11);
+        verify(mw, never()).getActiveStages(11);
     }
 
     @Test
     void omits_active_campaign_that_has_no_active_stage() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(10, "ACTIVE"), campaign(12, "ACTIVE")));
-        when(mw.getProgression(10)).thenReturn(List.of(stage(40, 999L, "COMPLETE")));
-        when(mw.getProgression(12)).thenReturn(List.of(stage(50, 27668L, "ACTIVE")));
+        when(mw.getActiveStages(10)).thenReturn(List.of()); // campaign is ACTIVE but has no ACTIVE stage
+        when(mw.getActiveStages(12)).thenReturn(List.of(new StageDto(50, 12, 5050, "ACTIVE")));
+        when(mw.getGraph(5050)).thenReturn(new GraphDto(5050, 27668, 282));
 
         assertThat(new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages())
                 .containsExactly(new ActiveStage(12, 50, 27668L));
@@ -79,7 +82,8 @@ class ActiveStageResolverTest {
     void caches_within_window_then_refreshes() {
         MwClient mw = mock(MwClient.class);
         when(mw.getCampaigns()).thenReturn(List.of(campaign(10, "ACTIVE")));
-        when(mw.getProgression(10)).thenReturn(List.of(stage(42, 775623L, "ACTIVE")));
+        when(mw.getActiveStages(10)).thenReturn(List.of(new StageDto(42, 10, 4200, "ACTIVE")));
+        when(mw.getGraph(4200)).thenReturn(new GraphDto(4200, 775623, 282));
 
         MutableClock clock = new MutableClock(Instant.parse("2026-06-20T00:00:00Z"));
         ActiveStageResolver resolver = new ActiveStageResolver(mw, clock);
@@ -100,5 +104,22 @@ class ActiveStageResolverTest {
         @Override public ZoneOffset getZone() { return ZoneOffset.UTC; }
         @Override public Clock withZone(java.time.ZoneId z) { return this; }
         @Override public Instant instant() { return now; }
+    }
+
+    /**
+     * The resolver must NOT read a campaign's progression. That series is the whole history —
+     * 21 MB and 143,000 points and growing — and scanning it for one stage id used to cost that
+     * on every refresh, for a few hundred bytes of answer.
+     */
+    @Test
+    void never_reads_the_progression() {
+        MwClient mw = mock(MwClient.class);
+        when(mw.getCampaigns()).thenReturn(List.of(campaign(10, "ACTIVE")));
+        when(mw.getActiveStages(10)).thenReturn(List.of(new StageDto(42, 10, 4200, "ACTIVE")));
+        when(mw.getGraph(4200)).thenReturn(new GraphDto(4200, 775623, 282));
+
+        new ActiveStageResolver(mw, Clock.systemUTC()).resolveActiveStages();
+
+        verify(mw, never()).getProgression(anyInt());
     }
 }


### PR DESCRIPTION
`ActiveStageResolver` found a campaign's ACTIVE stage by fetching its **entire progression** and scanning for the point marked ACTIVE.

That series is the whole history — **21.5 MB and 143,130 points**, growing with every stage advance — and it was refetched every 5 seconds. So ~4.3 MB/s of database query, JSON serialisation, transfer and parse, to extract one stage id and one clique count. The cost grew without bound while the answer stayed the same size.

The stage table already answers this directly, and is indexed on `(campaign_id, status)`:

```
/stages?campaignId=10&status=ACTIVE     255 bytes    12ms
/campaigns/10/progression            21,460,824 bytes   370ms
```

The clique count comes from the stage's base graph. `GraphDto` deliberately omits `edgeData` so the ~40 KB bitstring is never deserialized.

**Measured after deploying:**

| | before | after |
|---|---|---|
| middleware CPU | 7.72% | **3.03%** |
| dashboard backend memory | 1019 MiB | **423 MiB** |
| database statements | 105/s | 95/s |

The memory drop is the striking one — it was allocating and discarding 143,130 objects every 5 seconds. Throughput sampling is unaffected, and a test pins that the resolver never calls `getProgression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7XjzEBwfnWeVv9KRSrWWr