### PR TITLE
Track the QM's ILS escalation cap back to x32

### DIFF
--- a/ramsey-ui-web/src/ils.ts
+++ b/ramsey-ui-web/src/ils.ts
@@ -12,7 +12,10 @@ import type { ProgressionPointDto } from './types';
 // the drift. Worth serving them from the API if they change again.
 export const BASIN_STALE_STAGES = 1000;
 export const BASE_EDGE_PAIRS = 60;
-export const ESCALATION_CAP = 64; // geometric: multipliers 1,2,4,8,16,32,64
+export const ESCALATION_CAP = 32; // geometric: multipliers 1,2,4,8,16,32
+// Reverted 64 -> 32 on 2026-07-31 to track the QM. All five x64 (3840-pair) kicks stranded the
+// campaign ~30-53x above the incumbent; x32 recovers 15 times in 16. Rationale and measurements
+// live in ramsey-mw/docker/main/ramsey-compose.yml next to PERTURBATION_ESCALATION_CAP.
 
 export interface IlsState {
   incumbent: number;         // global campaign min — the graph the kicks are trying to beat


### PR DESCRIPTION
Tracks benfff85/ramsey-mw#184, which reverts `PERTURBATION_ESCALATION_CAP` to 32.

The ILS card's predicted next multiplier comes from `ESCALATION_CAP`, so if it stays at 64 the dashboard advertises an x64 kick the QM can no longer fire.

## Why the QM reverted

Campaign 10's 22 kicks are bimodal — an epoch either returns to ~1.0x the incumbent or strands on the ~785K shelf:

| kick size | kicks | recovered | stranded at 30-53x |
|---|---|---|---|
| 1920 pairs (x32) | 16 | **15** | 1 |
| 3840 pairs (x64) | 5 | **0** | 5 (17-27k stages each) |

A 3840-pair kick peaks at ~4.6M, essentially a random 282-coloring, so it discards the incumbent rather than perturbing it.

## Tests

No fixture changes needed — `ils.test.ts` derives its cases from the constant rather than hardcoding 64, which is precisely the drift that parameterisation was added to prevent (the earlier fixture hardcoded 6 kicks to overshoot a cap of 32, and silently stopped testing the clamp when the cap moved to 64). 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xr681DwNB55o46Ld3LjxZ
